### PR TITLE
feat: Basic impl of init_cuts method

### DIFF
--- a/players/group_3.py
+++ b/players/group_3.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import List
+from typing import List, Tuple
 from collections import deque
 
 import numpy as np
@@ -33,10 +33,36 @@ class Player:
         self.preplanned_moves = deque()
         self.request_served = 0
 
-    def move(self, current_percept) -> (int, List[int]):
+    def move(self, current_percept) -> Tuple[int, List[int]]:
+        self.init_cuts(current_percept=current_percept)  # TODO: just for debug and demonstration, move elsewhere later
         if current_percept.cake_len <= self.triangle_viable:
             return self.triangle(current_percept)
         return self.quadrangle(current_percept)
+
+    def init_cuts(self, current_percept) -> List[List[List[int]]]:
+        """
+        Given current_percept, returns the list of signficant (non-crumb) cuts to be made in the cake in format:
+        [
+            [[0, y1], [width, y1]],  # horizontal cut
+            [[0, y2], [width, y2]],  # horizontal cut
+            ...
+            [[x3, 0], [x3, length]],  # vertical cut
+            [[x4, 0], [x4, length]],  # vertical cut
+        ]
+        """
+        cake_len, cake_width = current_percept.cake_len, current_percept.cake_width
+        row_count, col_count = 2, 4
+        row_height, col_width = cake_len / row_count, cake_width / col_count
+        cuts = []
+
+        for i in range(1, row_count):
+            cuts.append([[0, i * row_height], [cake_width, i * row_height]])
+        for i in range(1, col_count):
+            cuts.append([[i * col_width, 0], [i * col_width, cake_len]])
+
+        print(f"{cake_len=}, {cake_width=}")
+        print(f"init_{cuts=}")
+        return cuts
 
     def quadrangle(self, current_percept):
         polygons = current_percept.polygons


### PR DESCRIPTION
Given current_percept, returns the list of signficant (non-crumb) cuts to be made in the cake in format:
```
  [
      [[0, y1], [width, y1]],  # horizontal cut
      [[0, y2], [width, y2]],  # horizontal cut
      ...
      [[x3, 0], [x3, length]],  # vertical cut
      [[x4, 0], [x4, length]],  # vertical cut
  ]
```

Currently hard coded, feel free to modify row_count, col_count to fit your needs. 

TODO 
- [ ] Think about ways to eliminate some row/col combinations
- [ ] Refactor to return multiple sets of cuts (of different row/col) if needed